### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+### What type of PR is this?
+
+_(bug/feature/cleanup/documentation)_
+
+### What this PR does / Why we need it?
+
+### Which Jira/Github issue(s) does this PR fix?
+
+_Resolves #_
+
+### Special notes for your reviewer
+
+### Pre-checks (if applicable)
+
+- [ ] Validated the changes in a hosted cluster
+- [ ] Included documentation changes with PR

--- a/OWNERS
+++ b/OWNERS
@@ -11,7 +11,7 @@ approvers:
   - cblecker
   - jharrington22
   - feichashao
-  - supreeth7 # temp
+  - supreeth7
   - Tafhim
 
 maintainers:


### PR DESCRIPTION
There are cases where PRs are submitted with no description. This is a poor posture from a compliance and review perspective. This PR adds a template to encourage engineers to answer a standard set of questions when submitted.