### PR TITLE
Change compliance type for CMO config

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -113,7 +113,7 @@ objects:
                       compliant: 2h
                       noncompliant: 45s
                   object-templates:
-                  - complianceType: mustonlyhave
+                  - complianceType: MustHave
                     objectDefinition:
                       apiVersion: v1
                       kind: ConfigMap


### PR DESCRIPTION
### What type of PR is this?
Bug 

### What this PR does / Why we need it?
Switches the compliance type for the dataplane metrics forwarder config from `mustonlyhave` to `musthave`.