### PR TITLE
Make the Telemeter server URL paramterized

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -7,6 +7,8 @@ parameters:
     required: true
   - name: IMAGE_DIGEST
     required: true
+  - name: TELEMETER_SERVER_URL
+    required: true
 objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
@@ -183,7 +185,7 @@ objects:
                                 - effect: NoSchedule
                                   key: node-role.kubernetes.io/worker
                                   operator: Exists
-                              telemeterServerURL: https://infogw.api.stage.openshift.com
+                              telemeterServerURL: ${TELEMETER_SERVER_URL}
                             prometheusOperator:
                               nodeSelector:
                                 node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / Why we need it?
The Telemeter server URL needs to by dynamic as per the OCM environment. This PR parameterized it to be patched by the App-SRE CD pipeline.

### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
