### PR TITLE
Add team leads and architects as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,16 +8,8 @@ reviewers:
 
 approvers:
   - wanghaoran1988
-  - cblecker
-  - jharrington22
   - feichashao
   - supreeth7
   - Tafhim
-
-maintainers:
-  - wanghaoran1988
-  - feichashao
-  - reetika-vyas
-  - supreeth7
-  - MitaliBhalla
-  - Tafhim
+  - srep-team-leads
+  - sre-architects

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+aliases:
+  srep-team-leads:
+    - fahlmant
+    - dustman9000
+    - NautiluX
+    - rogbas
+  sre-architects:
+    - cblecker
+    - jewzaam
+    - jharrington22


### PR DESCRIPTION
Add SRE-P Team Leads and Architects as approvers.

**Note:** ProwCI has no notion of `maintainers`, so it has been removed.