### PR TITLE
Fix route parsing for cluster name

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -130,7 +130,7 @@ objects:
                                 source: "DP"
                               replicas: 2
                               remoteWrite:
-                                - url: https://metrics-forwarder.apps.{{ ( split "." (lookup "route.openshift.io/v1" "Route" "openshift-monitoring" "prometheus-k8s").spec.host )._2 }}.hypershift.local
+                                - url: https://metrics-forwarder.apps.{{ ( split "." (lookup "route.openshift.io/v1" "Route" "openshift-monitoring" "prometheus-k8s").spec.host )._3 }}.hypershift.local
                                   remoteTimeout: 30s
                                   writeRelabelConfigs:
                                   - sourceLabels: [__tmp_openshift_cluster_id__]


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

HyperShift Dataplane routes changed so we need to parse a different index for valid cluster name

