### PR TITLE
OSD-16091 - Parse cluster name from Infrastructure

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -130,7 +130,7 @@ objects:
                                 source: "DP"
                               replicas: 2
                               remoteWrite:
-                                - url: https://metrics-forwarder.apps.{{ ( split "." (lookup "route.openshift.io/v1" "Route" "openshift-monitoring" "prometheus-k8s").spec.host )._3 }}.hypershift.local
+                                - url: https://metrics-forwarder.apps.{{ range $res := ((lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.platformStatus.aws.resourceTags) }}{{ if eq $res.key "api.openshift.com/name" }}{{ $res.value }}{{ end }}{{ end }}.hypershift.local
                                   remoteTimeout: 30s
                                   writeRelabelConfigs:
                                   - sourceLabels: [__tmp_openshift_cluster_id__]


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

We are currently parsing cluster name from a Prometheus route. This approach is not ideal and can break due to changes to DNS. So we have to use a reliable place to parse the cluster name from

### Which Jira/Github issue(s) does this PR fix?

[OSD-16091](https://issues.redhat.com//browse/OSD-16091)

### Explaination
The `Infrastructure` object holds the cluster name and other attributes in `.status.platformStatus.aws.resourceTags.`. This is a list of maps. So we have to iterate over it and get the value from the map where `key` equals `api.openshift.com/name`.

Currently this code assumes we will only have AWS infrastructure hence it does not check whether there is GCP infrastructure for example.

### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
