### PR TITLE
Remove Prom/AM PVC & Reduce retention to 1d

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -155,7 +155,7 @@ objects:
                                 - effect: NoSchedule
                                   key: node-role.kubernetes.io/worker
                                   operator: Exists
-                              retention: 11d
+                              retention: 1d
                             alertmanagerMain:
                               nodeSelector:
                                 node-role.kubernetes.io/worker: ""

--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -156,14 +156,6 @@ objects:
                                   key: node-role.kubernetes.io/worker
                                   operator: Exists
                               retention: 11d
-                              retentionSize: 90GB
-                              volumeClaimTemplate:
-                                metadata:
-                                  name: prometheus-data
-                                spec:
-                                  resources:
-                                    requests:
-                                      storage: 100Gi
                             alertmanagerMain:
                               nodeSelector:
                                 node-role.kubernetes.io/worker: ""
@@ -171,13 +163,6 @@ objects:
                                 - effect: NoSchedule
                                   key: node-role.kubernetes.io/worker
                                   operator: Exists
-                              volumeClaimTemplate:
-                                metadata:
-                                  name: alertmanager-data
-                                spec:
-                                  resources:
-                                    requests:
-                                      storage: 10Gi
                             telemeterClient:
                               nodeSelector:
                                 node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / Why we need it?
Red Hat only uses the in-cluster CMO to remote-write data plane metrics to HyperShift Management Clusters. This PR  **reduces** the retention to `1d` and **removes** the persistent volume claims of Prometheus and AlertManager to reduce customer-resource utilization.

### Which Jira/Github issue(s) does this PR fix?
Resolves: [OSD-15913](https://issues.redhat.com/browse/OSD-15913)

### Special notes for your reviewer
- Tested it in a staging-hosted cluster and the Monitoring CO looks stable.
- While it doesn't remove the PVCs for existing hosted clusters, the newly created ones won't have one.

### Pre-checks (if applicable)
- [x] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
