### PR TITLE
OSD-16608: added taints and tolerations to metrics-forwarder

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -241,6 +241,12 @@ spec:
                   hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
               topologyKey: kubernetes.io/hostname
             weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: metrics-forwarder
+            topologyKey: topology.kubernetes.io/zone
       containers:
         - name: nginx
           image: registry.access.redhat.com/ubi8/nginx-120

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -216,6 +216,31 @@ spec:
       labels:
         app: metrics-forwarder
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/hosted-control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - '{{.package.metadata.namespace}}'
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
         - name: nginx
           image: registry.access.redhat.com/ubi8/nginx-120
@@ -228,6 +253,15 @@ spec:
               subPath: nginx.conf
             - mountPath: /etc/nginx/cert
               name: nginx-cert
+      tolerations:
+        - effect: NoSchedule
+          key: hypershift.openshift.io/hosted-control-plane
+          operator: Equal
+          value: "true"
+        - effect: NoSchedule
+          key: hypershift.openshift.io/cluster
+          operator: Equal
+          value: '{{.package.metadata.namespace}}'
       volumes:
         - name: nginx-config
           configMap:


### PR DESCRIPTION



This PR updates the taints and tolerations for metrics-forwarder deployment to make it follow the hosted cluster workload topology.

### Which Jira/Github issue(s) does this PR fix?

[OSD-16608 ](https://issues.redhat.com/browse/OSD-16608)

### Testing

- [ ] Validated the changes by installing the package on a hosted control plane and verifying that metrics-forwarder pod schedules on the node as other components and runs successfully
