### PR TITLE
Make proxy activity visible on Pod logs

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -79,7 +79,7 @@ data:
                           '$status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"'
                           ' Proxy: "$proxy_host" "$upstream_addr"';
-      access_log  /var/log/nginx/access.log  main;
+      access_log  /dev/stdout  main;
       sendfile        on;
       keepalive_timeout  65;
       server {


### PR DESCRIPTION
### Special notes for your reviewer
This PR makes the proxy activity visible on Pod logs
```
10.128.67.214 - - [07/Jul/2023:16:40:30 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
10.128.67.214 - - [07/Jul/2023:16:40:30 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
10.128.123.1 - - [07/Jul/2023:16:40:35 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
10.128.123.1 - - [07/Jul/2023:16:40:35 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
10.128.123.1 - - [07/Jul/2023:16:40:35 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
10.128.123.1 - - [07/Jul/2023:16:40:35 +0000] "POST / HTTP/1.1" 204 0 "-" "Prometheus/2.39.1" "-" Proxy: "hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090" "172.30.44.118:9090"
```
### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
