### PR TITLE
Lower evaluation time of data plane prometheus config

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -112,7 +112,7 @@ objects:
                     name: metrics-forwarder-config
                   spec:
                     evaluationInterval:
-                      compliant: 2h
+                      compliant: 2m
                       noncompliant: 45s
                     object-templates:
                     - complianceType: MustHave

--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -112,7 +112,7 @@ objects:
                     name: metrics-forwarder-config
                   spec:
                     evaluationInterval:
-                      compliant: 2m
+                      compliant: 15m
                       noncompliant: 45s
                     object-templates:
                     - complianceType: MustHave


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_

### What this PR does / Why we need it?

This PR lowers the reconciliation interval for the data plane prometheus configuration. This is a short term fix to mitigate changes by customers while we don't have a validation webhook. 

Reason for the many ClusterMetricsMissing alerts reaching primary currently: customers have argocd installed (used for tekton pipelines), this patches our cluster-monitoring-config in the openshift monitoring namespace. 
We don't have any validation webhooks preventing this, and the reconciliation is currently 2 hrs. If we have no metrics from a cluster for 20 minutes, CMM triggers. 
The PR changes the reconciliation time to 2 minutes while we don't have a validation webhook yet. 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
