### PR TITLE
Persist HCP dataplane metrics like we do in classic OSD

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -172,7 +172,15 @@ objects:
                                   - effect: NoSchedule
                                     key: node-role.kubernetes.io/infra
                                     operator: Exists
-                                retention: 1d
+                                retention: 11d
+                                retentionSize: 90GB
+                                volumeClaimTemplate:
+                                  metadata:
+                                    name: prometheus-data
+                                  spec:
+                                    resources:
+                                      requests:
+                                        storage: 100Gi
                               alertmanagerMain:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
@@ -352,7 +360,15 @@ objects:
                                   - effect: NoSchedule
                                     key: node-role.kubernetes.io/infra
                                     operator: Exists
-                                retention: 1d
+                                retention: 11d
+                                retentionSize: 90GB
+                                volumeClaimTemplate:
+                                  metadata:
+                                    name: prometheus-data
+                                  spec:
+                                    resources:
+                                      requests:
+                                        storage: 100Gi
                               alertmanagerMain:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
### What type of PR is this?

bug/feature

### What this PR does / Why we need it?
Persist HCP dataplane metrics like we do in classic OSD - https://github.com/openshift/managed-cluster-config/blob/f04d5e10de29c948bf7cdf9ced57a2e3dda4e493/resources/cluster-monitoring-config/config.yaml#L28-L36

### Which Jira/Github issue(s) does this PR fix?

[OSD-18989](https://issues.redhat.com//browse/OSD-18989)