### PR TITLE
Adds request serving node affinity

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -155,20 +155,27 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
+          - preferece:
+              weight: 50
               matchExpressions:
               - key: hypershift.openshift.io/hosted-control-plane
                 operator: In
                 values:
                 - "true"
-            weight: 50
           - preference:
+              weight: 200
+              matchExpressions:
+              - key: hypershift.openshift.io/request-serving-component
+                operator: In
+                values:
+                - "true"
+          - preference:
+              weight: 100
               matchExpressions:
               - key: hypershift.openshift.io/cluster
                 operator: In
                 values:
                 - '{{.package.metadata.namespace}}'
-            weight: 100
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -212,6 +212,9 @@ spec:
           key: hypershift.openshift.io/cluster
           operator: Equal
           value: '{{.package.metadata.namespace}}'
+        - effect: NoSchedule
+          key: hypershift.openshift.io/request-serving-component
+          operator: Exists
       volumes:
         - name: nginx-config
           configMap:


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

Puts the request serving node toleration and affinity selector on.

This will need to be changed to `requireDuringSchedulingIgnoredDuringExecution` when the labels are pushed to prod. By keeping this as `preferredDuringSchedulingIgnoredDuringExecution` we don't block further promotions if necessary.

### Which Jira/Github issue(s) does this PR fix?

A step forward for [OSD-17369](https://issues.redhat.com//browse/OSD-17369)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
