### PR TITLE
Fix affinity specification

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -155,22 +155,22 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - preferece:
-              weight: 50
+          - weight: 50
+            preference:
               matchExpressions:
               - key: hypershift.openshift.io/hosted-control-plane
                 operator: In
                 values:
                 - "true"
-          - preference:
-              weight: 200
+          - weight: 200
+            preference:
               matchExpressions:
               - key: hypershift.openshift.io/request-serving-component
                 operator: In
                 values:
                 - "true"
-          - preference:
-              weight: 100
+          - weight: 100
+            preference:
               matchExpressions:
               - key: hypershift.openshift.io/cluster
                 operator: In


### PR DESCRIPTION
Discovered during validation of a new package-operator release.

PKO was logging a bunch of these:

```
2023-10-18T15:35:27Z	INFO	controllers.ObjectSet	API status error with empty reason string	{"ObjectSet": "ocm-staging-26ik5ksnpsstmo1slnordjp1p30hk9fl-cs-ci-srtbw/metrics-forwarder-79646cf8cc", "err": {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"failed to create typed patch object (ocm-staging-26ik5ksnpsstmo1slnordjp1p30hk9fl-cs-ci-srtbw/metrics-forwarder; apps/v1, Kind=Deployment): errors:\n  .spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preferece: field not declared in schema\n  .spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].preference.weight: field not declared in schema\n  .spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[2].preference.weight: field not declared in schema","code":500}}
```

Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#preferredschedulingterm-v1-core

### What type of PR is this?

Bugfix

### What this PR does / Why we need it?

Fixes deployment.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
