### PR TITLE
OSD-20049 ROSA HCP monitoring stack does not schedule on infra nodes

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -151,17 +151,17 @@ objects:
                                       insecureSkipVerify: true
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
+                                affinity:
+                                  nodeAffinity:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      - preference:
+                                          matchExpressions:
+                                            - key: node-role.kubernetes.io/infra
+                                              operator: Exists
+                                        weight: 1
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
-                                    whenUnsatisfiable: ScheduleAnyway
-                                    labelSelector:
-                                      matchLabels:
-                                        app: prometheus
-                                    nodeAffinityPolicy: Honor
-                                    nodeTaintsPolicy: Honor
-                                  - maxSkew: 1
-                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:
@@ -184,17 +184,17 @@ objects:
                               alertmanagerMain:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
+                                affinity:
+                                  nodeAffinity:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      - preference:
+                                          matchExpressions:
+                                            - key: node-role.kubernetes.io/infra
+                                              operator: Exists
+                                        weight: 1
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
-                                    whenUnsatisfiable: ScheduleAnyway
-                                    labelSelector:
-                                      matchLabels:
-                                        app: prometheus
-                                    nodeAffinityPolicy: Honor
-                                    nodeTaintsPolicy: Honor
-                                  - maxSkew: 1
-                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:
@@ -339,17 +339,17 @@ objects:
                                       insecureSkipVerify: true
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
+                                affinity:
+                                  nodeAffinity:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      - preference:
+                                          matchExpressions:
+                                            - key: node-role.kubernetes.io/infra
+                                              operator: Exists
+                                        weight: 1
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
-                                    whenUnsatisfiable: ScheduleAnyway
-                                    labelSelector:
-                                      matchLabels:
-                                        app: prometheus
-                                    nodeAffinityPolicy: Honor
-                                    nodeTaintsPolicy: Honor
-                                  - maxSkew: 1
-                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:
@@ -364,17 +364,17 @@ objects:
                               alertmanagerMain:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
+                                affinity:
+                                  nodeAffinity:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      - preference:
+                                          matchExpressions:
+                                            - key: node-role.kubernetes.io/infra
+                                              operator: Exists
+                                        weight: 1
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
-                                    whenUnsatisfiable: ScheduleAnyway
-                                    labelSelector:
-                                      matchLabels:
-                                        app: prometheus
-                                    nodeAffinityPolicy: Honor
-                                    nodeTaintsPolicy: Honor
-                                  - maxSkew: 1
-                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:


### PR DESCRIPTION
Attempt to fix bug issue where the prometheus and alertmanager pods would not schedule on infra nodes due to not having multiple topology domains.

Issue detailed in https://issues.redhat.com/browse/OHSS-29359

### What type of PR is this?
Bug


_Resolves #_
Issue detailed in https://issues.redhat.com/browse/OHSS-29359
https://issues.redhat.com/browse/OSD-20049


