### PR TITLE
Allow maxSkew: 2 to encourage pods to schedule on 2 infra nodes

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -168,6 +168,14 @@ objects:
                                         app: prometheus
                                     nodeAffinityPolicy: Honor
                                     nodeTaintsPolicy: Honor
+                                  - maxSkew: 2
+                                    topologyKey: node-role.kubernetes.io/infra
+                                    whenUnsatisfiable: ScheduleAnyway
+                                    labelSelector:
+                                      matchLabels:
+                                        app: prometheus
+                                    nodeAffinityPolicy: Honor
+                                    nodeTaintsPolicy: Honor
                                 tolerations:
                                   - effect: NoSchedule
                                     key: node-role.kubernetes.io/infra
@@ -195,6 +203,14 @@ objects:
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
+                                    whenUnsatisfiable: ScheduleAnyway
+                                    labelSelector:
+                                      matchLabels:
+                                        app: prometheus
+                                    nodeAffinityPolicy: Honor
+                                    nodeTaintsPolicy: Honor
+                                  - maxSkew: 2
+                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:
@@ -356,6 +372,14 @@ objects:
                                         app: prometheus
                                     nodeAffinityPolicy: Honor
                                     nodeTaintsPolicy: Honor
+                                  - maxSkew: 2
+                                    topologyKey: node-role.kubernetes.io/infra
+                                    whenUnsatisfiable: ScheduleAnyway
+                                    labelSelector:
+                                      matchLabels:
+                                        app: prometheus
+                                    nodeAffinityPolicy: Honor
+                                    nodeTaintsPolicy: Honor
                                 tolerations:
                                   - effect: NoSchedule
                                     key: node-role.kubernetes.io/infra
@@ -375,6 +399,14 @@ objects:
                                 topologySpreadConstraints:
                                   - maxSkew: 1
                                     topologyKey: topology.kubernetes.io/zone
+                                    whenUnsatisfiable: ScheduleAnyway
+                                    labelSelector:
+                                      matchLabels:
+                                        app: prometheus
+                                    nodeAffinityPolicy: Honor
+                                    nodeTaintsPolicy: Honor
+                                  - maxSkew: 2
+                                    topologyKey: node-role.kubernetes.io/infra
                                     whenUnsatisfiable: ScheduleAnyway
                                     labelSelector:
                                       matchLabels:


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
topologySpreadConstraints encourages pods to schedule one of the
monitoring pods on an infra node and one of them "not" on an
infra node. With maxSkew: 1, only one pod is allowed to be on an infra
node, otherwise if two pods were on an infra node and zero otherwise,
the "skew" would be 2.

With maxSkew: 2, we allow for a skew of 2, which results in both pods
scheduling on infra nodes.

This is a hack because the cluster monitoring operator does
not yet support nodeAffinity, which would solve this problem in a
clearer fashion.

### Which Jira/Github issue(s) does this PR fix?

OSD-20049
OHSS-29359

### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
