### PR TITLE
OSD-21259: Disable telemetry for data plane

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -7,8 +7,6 @@ parameters:
     required: true
   - name: IMAGE_DIGEST
     required: true
-  - name: TELEMETER_SERVER_URL
-    required: true
 objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
@@ -206,13 +204,7 @@ objects:
                                     key: node-role.kubernetes.io/infra
                                     operator: Exists
                               telemeterClient:
-                                nodeSelector:
-                                  node-role.kubernetes.io/worker: ""
-                                tolerations:
-                                  - effect: NoSchedule
-                                    key: node-role.kubernetes.io/infra
-                                    operator: Exists
-                                telemeterServerURL: ${TELEMETER_SERVER_URL}
+                                enabled: false
                               prometheusOperator:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
@@ -393,13 +385,7 @@ objects:
                                       requests:
                                         storage: 10Gi
                               telemeterClient:
-                                nodeSelector:
-                                  node-role.kubernetes.io/worker: ""
-                                tolerations:
-                                  - effect: NoSchedule
-                                    key: node-role.kubernetes.io/infra
-                                    operator: Exists
-                                telemeterServerURL: ${TELEMETER_SERVER_URL}
+                                enabled: false
                               prometheusOperator:
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / Why we need it?
Disables telemetry for HyperShift data plane avoiding duplication as the data plane telemetry metrics are forwarded to telemeter via the Management Cluster.

### Which Jira/Github issue(s) does this PR fix?
Resolves: https://issues.redhat.com/browse/OSD-21259

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
