### PR TITLE
Remove dependency on managed cluster CR availability

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -58,9 +58,6 @@ objects:
             name: placement-metrics-forwarder
             namespace: openshift-acm-policies
           spec:
-            clusterConditions:
-              - status: "True"
-                type: ManagedClusterConditionAvailable
             clusterSelector:
               matchExpressions:
                 - key: hypershift.open-cluster-management.io/management-cluster
@@ -246,9 +243,6 @@ objects:
             name: placement-metrics-forwarder-config
             namespace: openshift-acm-policies
           spec:
-            clusterConditions:
-              - status: "True"
-                type: ManagedClusterConditionAvailable
             clusterSelector:
               matchExpressions:
                 - key: hypershift.open-cluster-management.io/hosted-cluster
@@ -427,9 +421,6 @@ objects:
             name: placement-metrics-forwarder-config-non-uwm
             namespace: openshift-acm-policies
           spec:
-            clusterConditions:
-              - status: "True"
-                type: ManagedClusterConditionAvailable
             clusterSelector:
               matchExpressions:
                 - key: hypershift.open-cluster-management.io/hosted-cluster


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_

### What this PR does / Why we need it?
This PR removes the dependency of the policy deployment on the managed cluster CR's availability.
The CR's availability can toggle between True/False blocking the deployment of policy updates.
With this change, new policy updates will be deployed regardless of the CR's 'Available' status condition.

### Which Jira/Github issue(s) does this PR fix?
Resolves: https://issues.redhat.com/browse/OSD-21462

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
