### PR TITLE
[OSD-21606] update the prometheus remote write to use apiServerInternalURI from infrastructure

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -127,7 +127,7 @@ objects:
                                   source: "DP"
                                 replicas: 2
                                 remoteWrite:
-                                  - url: https://metrics-forwarder.apps.{{ range $res := ((lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.platformStatus.aws.resourceTags) }}{{ if eq $res.key "api.openshift.com/name" }}{{ $res.value }}{{ end }}{{ end }}.hypershift.local
+                                  - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
                                     remoteTimeout: 30s
                                     writeRelabelConfigs:
                                     - sourceLabels: [__tmp_openshift_cluster_id__]
@@ -312,7 +312,7 @@ objects:
                                   source: "DP"
                                 replicas: 2
                                 remoteWrite:
-                                  - url: https://metrics-forwarder.apps.{{ range $res := ((lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.platformStatus.aws.resourceTags) }}{{ if eq $res.key "api.openshift.com/name" }}{{ $res.value }}{{ end }}{{ end }}.hypershift.local
+                                  - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
                                     remoteTimeout: 30s
                                     writeRelabelConfigs:
                                     - sourceLabels: [__tmp_openshift_cluster_id__]


### PR DESCRIPTION
…nfrastructure

### What type of PR is this?
_(/feature/)_

### What this PR does / Why we need it?
With the new OCM side change, the cluster naming policy will be changed, the cluster name may not be the same as the dns name for now.
Update the prometheus remote write to match the same value as the internal api endpoint

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-21606](https://issues.redhat.com//browse/OSD-21606)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
