### PR TITLE
[OSD-21416] update the tolerations to fix the pod periodic restart issue

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -158,7 +158,7 @@ spec:
           - weight: 50
             preference:
               matchExpressions:
-              - key: hypershift.openshift.io/hosted-control-plane
+              - key: hypershift.openshift.io/control-plane
                 operator: In
                 values:
                 - "true"
@@ -205,7 +205,7 @@ spec:
               name: nginx-cert
       tolerations:
         - effect: NoSchedule
-          key: hypershift.openshift.io/hosted-control-plane
+          key: hypershift.openshift.io/control-plane
           operator: Equal
           value: "true"
         - effect: NoSchedule
@@ -214,7 +214,8 @@ spec:
           value: '{{.package.metadata.namespace}}'
         - effect: NoSchedule
           key: hypershift.openshift.io/request-serving-component
-          operator: Exists
+          operator: Equal
+          value: "true"
       volumes:
         - name: nginx-config
           configMap:


### PR DESCRIPTION
### What type of PR is this?

_(bug)_

### What this PR does / Why we need it?

The metrics-forwarder pod got deleted/recreated every 15 minutes.
I am not 100% sure, but it should be related to the incorrect/mismatch tolerations key `hypershift.openshift.io/request-serving-component`.

Update the deployment and tested manually, the pod can be running without deletion.

The other fix is just to update with the correct node labels

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-21416](https://issues.redhat.com//browse/OSD-21416)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
