### PR TITLE
fix: remove replicas from config

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -125,7 +125,6 @@ objects:
                               prometheusK8s:
                                 externalLabels:
                                   source: "DP"
-                                replicas: 2
                                 remoteWrite:
                                   - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
                                     remoteTimeout: 30s


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_

/bug

### What this PR does / Why we need it?

in 4.18, the config parsing became more strict and is causing this to
fail

Signed-off-by: Brady Pratt <bpratt@redhat.com>

https://redhat-internal.slack.com/archives/C07QEA1PDFX/p1729770251694829
