### PR TITLE
[OSD-25656] Enhance the affinity rules to avoid pod mis-scheduling

### DIFF
--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -149,24 +149,18 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              # Term 1: Try to match the cluster label if present
+              # Term: Try to match both the cluster labels if present
               - matchExpressions:
                   - key: hypershift.openshift.io/cluster
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
-              # Term 2: Fallback to worker nodes if cluster label is missing
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/worker
-                    operator: Exists
-	      # Term 3: Additional fallback to control-plane-labeled nodes
-	      - matchExpressions:
-	          - key: hypershift.openshift.io/control-plane
-	            operator: In
-		    values:
-	              - 'true'	
+		  - key: hypershift.openshift.io/request-serving-component
+            	    operator: In
+                    values:
+                      - 'true'
           preferredDuringSchedulingIgnoredDuringExecution:
-            # Strong preference for nodes with the correct cluster label
+            # Preference for nodes with the correct cluster label
             - weight: 100
               preference:
                 matchExpressions:
@@ -174,21 +168,22 @@ spec:
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
-            - weight: 90
+            # Preference for nodes with the request-serving-component label
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: hypershift.openshift.io/request-serving-component
                     operator: In
                     values:
                       - 'true'
-            - weight: 80
+            - weight: 90
               preference:
                 matchExpressions:
                   - key: hypershift.openshift.io/control-plane
                     operator: In
                     values:
                       - 'true'
-            - weight: 70
+            - weight: 80
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/worker

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -149,7 +149,7 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              # Term: Try to match both the cluster labels if present
+              # Term: Try to match both the required cluster labels if present
               - matchExpressions:
                   - key: hypershift.openshift.io/cluster
                     operator: In
@@ -160,7 +160,7 @@ spec:
                     values:
                       - 'true'
           preferredDuringSchedulingIgnoredDuringExecution:
-            # Preference for nodes with the correct cluster label
+            # Preference for nodes with both required labels
             - weight: 100
               preference:
                 matchExpressions:
@@ -168,10 +168,6 @@ spec:
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
-            # Preference for nodes with the request-serving-component label
-            - weight: 100
-              preference:
-                matchExpressions:
                   - key: hypershift.openshift.io/request-serving-component
                     operator: In
                     values:
@@ -179,11 +175,25 @@ spec:
             - weight: 90
               preference:
                 matchExpressions:
+                  - key: hypershift.openshift.io/cluster
+                    operator: In
+                    values:
+                      - '{{.package.metadata.namespace}}'
+            - weight: 80
+              preference:
+                matchExpressions:
+		  - key: hypershift.openshift.io/request-serving-component
+            	    operator: In
+                    values:
+                      - 'true'
+            - weight: 70
+              preference:
+                matchExpressions:
                   - key: hypershift.openshift.io/control-plane
                     operator: In
                     values:
                       - 'true'
-            - weight: 80
+            - weight: 60
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/worker

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -159,14 +159,12 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/worker
                     operator: Exists
-
 	      # Term 3: Additional fallback to control-plane-labeled nodes
 	      - matchExpressions:
 	          - key: hypershift.openshift.io/control-plane
 	            operator: In
 		    values:
 	              - 'true'	
-
           preferredDuringSchedulingIgnoredDuringExecution:
             # Strong preference for nodes with the correct cluster label
             - weight: 100

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -154,6 +154,14 @@ spec:
     spec:
       affinity:
         nodeAffinity:
+	  requiredDuringSchedulingIgnoredDuringExecution:
+          # Enforce scheduling on nodes with the correct hypershift.openshift.io/cluster label
+          nodeSelectorTerms:
+	  - matchExpressions:
+            - key: hypershift.openshift.io/cluster
+	      operator: In
+	      values:
+	      - '{{.package.metadata.namespace}}'
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50
             preference:
@@ -169,13 +177,12 @@ spec:
                 operator: In
                 values:
                 - "true"
-          - weight: 70
-            preference:
-              matchExpressions:
-              - key: hypershift.openshift.io/cluster
-                operator: In
-                values:
-                - '{{.package.metadata.namespace}}'
+          # Fallback preference to any worker node (for cases where labels are missing)
+	  - weight: 30
+	    preference:
+	      matchExpressions:
+	      - key: node-role.kubernetes.io/worker
+		operator: Exists
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -22,8 +22,8 @@ spec:
     labels:
       app: metrics-forwarder
 
-  duration: 25960h 
-  renewBefore: 360h # 15d
+  duration: 25960h
+  renewBefore: 360h  # 15d
   subject:
     organizations:
       - openshift
@@ -114,25 +114,25 @@ metadata:
     package-operator.run/phase: deploy
 spec:
   egress:
-  - ports:
-    - port: 5353
-      protocol: UDP
-    - port: 5353
-      protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-observability-operator
-      podSelector: {}
+    - ports:
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-observability-operator
+          podSelector: {}
   podSelector:
     matchLabels:
       app: metrics-forwarder
   policyTypes:
-  - Egress
+    - Egress
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -154,56 +154,57 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-	  requiredDuringSchedulingIgnoredDuringExecution:
-          # Enforce scheduling on nodes with the correct hypershift.openshift.io/cluster label
+          requiredDuringSchedulingIgnoredDuringExecution: null
           nodeSelectorTerms:
-	  - matchExpressions:
-            - key: hypershift.openshift.io/cluster
-	      operator: In
-	      values:
-	      - '{{.package.metadata.namespace}}'
+            - matchExpressions:
+                - key: hypershift.openshift.io/cluster
+                  operator: In
+                  values:
+                    - '{{.package.metadata.namespace}}'
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: hypershift.openshift.io/control-plane
-                operator: In
-                values:
-                - "true"
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: hypershift.openshift.io/request-serving-component
-                operator: In
-                values:
-                - "true"
-          # Fallback preference to any worker node (for cases where labels are missing)
-	  - weight: 30
-	    preference:
-	      matchExpressions:
-	      - key: node-role.kubernetes.io/worker
-		operator: Exists
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/control-plane
+                    operator: In
+                    values:
+                      - 'true'
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/request-serving-component
+                    operator: In
+                    values:
+                      - 'true'
+            - weight: 30
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: metrics-forwarder
-            topologyKey: topology.kubernetes.io/zone
+            - labelSelector:
+                matchLabels:
+                  app: metrics-forwarder
+              topologyKey: topology.kubernetes.io/zone
       automountServiceAccountToken: false
       containers:
         - name: nginx
           image: registry.access.redhat.com/ubi8/nginx-120
-          command: ["nginx", "-g", "daemon off;"]
+          command:
+            - nginx
+            - '-g'
+            - daemon off;
           ports:
-          - containerPort: 8001
+            - containerPort: 8001
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf
@@ -214,7 +215,7 @@ spec:
         - effect: NoSchedule
           key: hypershift.openshift.io/control-plane
           operator: Equal
-          value: "true"
+          value: 'true'
         - effect: NoSchedule
           key: hypershift.openshift.io/cluster
           operator: Equal
@@ -222,7 +223,7 @@ spec:
         - effect: NoSchedule
           key: hypershift.openshift.io/request-serving-component
           operator: Equal
-          value: "true"
+          value: 'true'
       volumes:
         - name: nginx-config
           configMap:
@@ -243,10 +244,10 @@ spec:
   selector:
     app: metrics-forwarder
   ports:
-  - protocol: TCP
-    port: 8003
-    targetPort: 8003
-    name: nginx
+    - protocol: TCP
+      port: 8003
+      targetPort: 8003
+      name: nginx
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -269,4 +270,3 @@ spec:
     name: metrics-forwarder
     weight: 100
   wildcardPolicy: None
-

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -20,7 +20,6 @@ spec:
   secretTemplate:
     labels:
       app: metrics-forwarder
-
   duration: 25960h
   renewBefore: 360h
   subject:
@@ -84,17 +83,16 @@ data:
         ssl_certificate /etc/nginx/cert/tls.crt;
         ssl_certificate_key  /etc/nginx/cert/tls.key;
 
-
         location /healthz {
           return 200;
         }
 
         location / {
           proxy_pass http://hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090/api/v1/write;
-            proxy_buffering off;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Forwarded-Port $server_port;
+          proxy_buffering off;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Forwarded-Port $server_port;
         }
       }
     }
@@ -149,18 +147,16 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              # Term: Try to match both the required cluster labels if present
               - matchExpressions:
                   - key: hypershift.openshift.io/cluster
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
-		  - key: hypershift.openshift.io/request-serving-component
-            	    operator: In
+                  - key: hypershift.openshift.io/request-serving-component
+                    operator: In
                     values:
                       - 'true'
           preferredDuringSchedulingIgnoredDuringExecution:
-            # Preference for nodes with both required labels
             - weight: 100
               preference:
                 matchExpressions:
@@ -182,8 +178,8 @@ spec:
             - weight: 80
               preference:
                 matchExpressions:
-		  - key: hypershift.openshift.io/request-serving-component
-            	    operator: In
+                  - key: hypershift.openshift.io/request-serving-component
+                    operator: In
                     values:
                       - 'true'
             - weight: 70
@@ -198,7 +194,6 @@ spec:
                 matchExpressions:
                   - key: node-role.kubernetes.io/worker
                     operator: Exists
-
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -207,14 +202,12 @@ spec:
                     hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
                 topologyKey: kubernetes.io/hostname
               weight: 100
-
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app: metrics-forwarder
               topologyKey: topology.kubernetes.io/zone
-
       automountServiceAccountToken: false
       containers:
         - name: nginx
@@ -273,7 +266,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    hypershift.openshift.io/hosted-control-plane: {{.package.metadata.namespace}}
+    hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
     hypershift.openshift.io/internal-route: "true"
   annotations:
     package-operator.run/phase: expose

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -152,10 +152,6 @@ spec:
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
-                  - key: hypershift.openshift.io/request-serving-component
-                    operator: In
-                    values:
-                      - 'true'
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
               preference:
@@ -171,25 +167,11 @@ spec:
             - weight: 90
               preference:
                 matchExpressions:
-                  - key: hypershift.openshift.io/cluster
-                    operator: In
-                    values:
-                      - '{{.package.metadata.namespace}}'
-            - weight: 80
-              preference:
-                matchExpressions:
-                  - key: hypershift.openshift.io/request-serving-component
-                    operator: In
-                    values:
-                      - 'true'
-            - weight: 70
-              preference:
-                matchExpressions:
                   - key: hypershift.openshift.io/control-plane
                     operator: In
                     values:
                       - 'true'
-            - weight: 60
+            - weight: 80
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/worker

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -154,13 +154,13 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution: null
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: hypershift.openshift.io/cluster
-                  operator: In
-                  values:
-                    - '{{.package.metadata.namespace}}'
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: hypershift.openshift.io/cluster
+                    operator: In
+                    values:
+                      - '{{.package.metadata.namespace}}'
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 50
               preference:

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -160,6 +160,13 @@ spec:
                   - key: node-role.kubernetes.io/worker
                     operator: Exists
 
+	      # Term 3: Additional fallback to control-plane-labeled nodes
+	      - matchExpressions:
+	          - key: hypershift.openshift.io/control-plane
+	            operator: In
+		    values:
+	              - 'true'	
+
           preferredDuringSchedulingIgnoredDuringExecution:
             # Strong preference for nodes with the correct cluster label
             - weight: 100

--- a/package/resources.yaml.gotmpl
+++ b/package/resources.yaml.gotmpl
@@ -16,14 +16,13 @@ metadata:
     package-operator.run/phase: certman-cert
   name: metrics-forwarder-cert
 spec:
-  # Secret names are always required.
   secretName: metrics-forwarder-secret
   secretTemplate:
     labels:
       app: metrics-forwarder
 
   duration: 25960h
-  renewBefore: 360h  # 15d
+  renewBefore: 360h
   subject:
     organizations:
       - openshift
@@ -35,18 +34,12 @@ spec:
   usages:
     - server auth
     - client auth
-  # At least one of a DNS Name, URI, or IP address is required.
   dnsNames:
-    - apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{end}}.hypershift.local
+    - apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{ end }}.hypershift.local
     - localhost
-  # Issuer references are always required.
   issuerRef:
     name: metrics-forwarder-ca-issuer
-    # We can reference ClusterIssuers by changing the kind here.
-    # The default value is Issuer (i.e. a locally namespaced Issuer)
     kind: Issuer
-    # This is optional since cert-manager will default to this value however
-    # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
 ---
 apiVersion: v1
@@ -86,7 +79,7 @@ data:
         listen 8001;
         listen 8003 ssl;
 
-        server_name metrics-forwarder.apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{end}}.hypershift.local;
+        server_name metrics-forwarder.apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{ end }}.hypershift.local;
 
         ssl_certificate /etc/nginx/cert/tls.crt;
         ssl_certificate_key  /etc/nginx/cert/tls.key;
@@ -156,31 +149,46 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
+              # Term 1: Try to match the cluster label if present
               - matchExpressions:
                   - key: hypershift.openshift.io/cluster
                     operator: In
                     values:
                       - '{{.package.metadata.namespace}}'
+              # Term 2: Fallback to worker nodes if cluster label is missing
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
+            # Strong preference for nodes with the correct cluster label
+            - weight: 100
               preference:
                 matchExpressions:
-                  - key: hypershift.openshift.io/control-plane
+                  - key: hypershift.openshift.io/cluster
                     operator: In
                     values:
-                      - 'true'
-            - weight: 100
+                      - '{{.package.metadata.namespace}}'
+            - weight: 90
               preference:
                 matchExpressions:
                   - key: hypershift.openshift.io/request-serving-component
                     operator: In
                     values:
                       - 'true'
-            - weight: 30
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/control-plane
+                    operator: In
+                    values:
+                      - 'true'
+            - weight: 70
               preference:
                 matchExpressions:
                   - key: node-role.kubernetes.io/worker
                     operator: Exists
+
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -189,12 +197,14 @@ spec:
                     hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
                 topologyKey: kubernetes.io/hostname
               weight: 100
+
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app: metrics-forwarder
               topologyKey: topology.kubernetes.io/zone
+
       automountServiceAccountToken: false
       containers:
         - name: nginx
@@ -259,7 +269,7 @@ metadata:
     package-operator.run/phase: expose
   name: metrics-forwarder
 spec:
-  host: metrics-forwarder.apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{end}}.hypershift.local
+  host: metrics-forwarder.apps.{{ with $x := .package.metadata.namespace }}{{ (splitn "-" 4 $x)._3 }}{{ end }}.hypershift.local
   tls:
     insecureEdgeTerminationPolicy: None
     termination: passthrough


### PR DESCRIPTION
### What type of PR is this?

_(bug)_

### What this PR does / Why we need it?
Enhance the affinity rules to avoid metrics-forwarder pod mis-scheduling.

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-25656

### For reviewer
Based on the ticket description, the current logic to determine if the metrics-forwarder pod is mis-scheduled is:

#### 1. Check the node label:
- For each node running a metrics-forwarder pod, check the value of the hypershift.openshift.io/cluster label

#### 2. Compare namespace and serving node label:
- Compare the namespace of the metrics-forwarder pod to the value of the hypershift.openshift.io/cluster label on the serving node.
- If the namespace of the pod does not match the value of the hypershift.openshift.io/cluster label, the pod is considered mis-scheduled.

So, to resolve the mis-scheduling issue, I just enforce strict affinity rules in the metrics-forwarder deployment config to ensure the pod is scheduled only on nodes with the hypershift.openshift.io/cluster label matching the pod's namespace. 

Also, based on the test outcome, I can see there is case that many serving nodes have the hypershift.openshift.io/cluster label missing, we need to provide a affinity configuration that accommodates these scenarios as well.

Basically, in the PR, I just:
- Added required "requiredDuringSchedulingIgnoredDuringExecution" with the hypershift.openshift.io/cluster label.
- Keep the previous affinity rules for handling the label missing or other edge cases.

**P.S** More context and test outcome is in the Jira ticket [OSD-25656](https://issues.redhat.com//browse/OSD-25656)