### PR TITLE
fix: remove replicas from prometheusK8s config in metrics-forwarder-config-non-uwm

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -309,7 +309,6 @@ objects:
                               prometheusK8s:
                                 externalLabels:
                                   source: "DP"
-                                replicas: 2
                                 remoteWrite:
                                   - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
                                     remoteTimeout: 30s


### PR DESCRIPTION

### What type of PR is this?

_bug_

### What this PR does / Why we need it?
fix: remove replicas from prometheusK8s config in metrics-forwarder-config-non-uwm

follow up on https://github.com/openshift/hypershift-dataplane-metrics-forwarder/commit/6370dbccc6ea4ff24bb52568e694d873e97f36c2, fixing the same thing in the `metrics-forwarder-config-non-uwm` policy

in 4.18 and 4.17.5+, the config parsing became more strict and is causing this to fail

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
