### PR TITLE
Feat(SREP-748): disable hosted cluster metrics forwarding

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -123,28 +123,6 @@ objects:
                             config.yaml: |
                               enableUserWorkload: true
                               prometheusK8s:
-                                externalLabels:
-                                  source: "DP"
-                                remoteWrite:
-                                  - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
-                                    remoteTimeout: 30s
-                                    writeRelabelConfigs:
-                                    - sourceLabels: [__tmp_openshift_cluster_id__]
-                                      targetLabel: _id
-                                      action: replace
-                                    - sourceLabels: [__name__]
-                                      regex: '(apiserver_request_duration_seconds_bucket|apiserver_request_duration_seconds_count|apiserver_request_total|kube_node_labels|cluster:capacity_cpu_cores:sum|cluster:capacity_memory_bytes:sum|cluster:memory_usage_bytes:sum|cluster:node_instance_type_count:sum|cluster:virt_platform_nodes:sum|console_url|kube_node_spec_unschedulable|kube_node_status_condition|node_role_os_version_machine:cpu_capacity_cores:sum|node_role_os_version_machine:cpu_capacity_cores:sum|node_role_os_version_machine:cpu_capacity_sockets:sum|up|probe_success)'
-                                      action: keep
-                                    queueConfig:
-                                      capacity: 10000
-                                      maxShards: 500
-                                      minShards: 1
-                                      maxSamplesPerSend: 2000
-                                      batchSendDeadline: 60s
-                                      minBackoff: 30ms
-                                      maxBackoff: 30s
-                                    tlsConfig:
-                                      insecureSkipVerify: true
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
                                 topologySpreadConstraints:
@@ -307,28 +285,6 @@ objects:
                             config.yaml: |
                               enableUserWorkload: false
                               prometheusK8s:
-                                externalLabels:
-                                  source: "DP"
-                                remoteWrite:
-                                  - url: {{ ( trimAll ":443" (( lookup "config.openshift.io/v1" "Infrastructure" "default" "cluster").status.apiServerInternalURI )) | replace "//api" "//metrics-forwarder.apps" }}
-                                    remoteTimeout: 30s
-                                    writeRelabelConfigs:
-                                    - sourceLabels: [__tmp_openshift_cluster_id__]
-                                      targetLabel: _id
-                                      action: replace
-                                    - sourceLabels: [__name__]
-                                      regex: '(apiserver_request_duration_seconds_bucket|apiserver_request_duration_seconds_count|apiserver_request_total|kube_node_labels|cluster:capacity_cpu_cores:sum|cluster:capacity_memory_bytes:sum|cluster:memory_usage_bytes:sum|cluster:node_instance_type_count:sum|cluster:virt_platform_nodes:sum|console_url|kube_node_spec_unschedulable|kube_node_status_condition|node_role_os_version_machine:cpu_capacity_cores:sum|node_role_os_version_machine:cpu_capacity_cores:sum|node_role_os_version_machine:cpu_capacity_sockets:sum|up|probe_success)'
-                                      action: keep
-                                    queueConfig:
-                                      capacity: 10000
-                                      maxShards: 500
-                                      minShards: 1
-                                      maxSamplesPerSend: 2000
-                                      batchSendDeadline: 60s
-                                      minBackoff: 30ms
-                                      maxBackoff: 30s
-                                    tlsConfig:
-                                      insecureSkipVerify: true
                                 nodeSelector:
                                   node-role.kubernetes.io/worker: ""
                                 topologySpreadConstraints:


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Disable dataplane metrics forwarding as part of handing over CMO to customers. Cleanup of the metrics forwarder deployment on MCs will be a follow-up part of milestone 2. 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_ https://issues.redhat.com/browse/SREP-748 

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
