### PR TITLE
Cleanup: add pruneObjectBehavior to metrics-forwarder policy beofre removing it

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -30,6 +30,7 @@ objects:
             name: metrics-forwarder
             namespace: openshift-acm-policies
           spec:
+            pruneObjectBehavior: DeleteIfCreated
             disabled: false
             remediationAction: enforce
             policy-templates:


### PR DESCRIPTION


### What type of PR is this?
Adds DeleteIfCreated to the metrics-forwarder policy, which will remove the underlying PKO packages once we delete the SSS. 

### What this PR does / Why we need it?

Part of the removal of metrics-forwarding. 

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/SREP-748

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
