### PR TITLE
Fix: move pruneObjectBehavior to underlying metrics-forwarder configpolicy spec

### DIFF
--- a/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-hypershift-dataplane-metrics-forwarder.SelectorSyncSet.yaml.tmpl
@@ -30,7 +30,6 @@ objects:
             name: metrics-forwarder
             namespace: openshift-acm-policies
           spec:
-            pruneObjectBehavior: DeleteIfCreated
             disabled: false
             remediationAction: enforce
             policy-templates:
@@ -40,6 +39,7 @@ objects:
                   metadata:
                     name: metrics-forwarder
                   spec:
+                    pruneObjectBehavior: DeleteIfCreated
                     evaluationInterval:
                       compliant: 2m
                       noncompliant: 45s


### PR DESCRIPTION
### What type of PR is this?

Fix

### What this PR does / Why we need it?

Fixes previous PR to move the pruneObjectBehavior to the configurationpolicy instead of the policy. This will actually result in the metrics-forwarder packages getting deleted. 

Tested on int. 

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/SREP-748


### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Validated the changes in a hosted cluster
- [ ] Included documentation changes with PR
